### PR TITLE
LocationReference 

### DIFF
--- a/PokemonGo/RocketAPI/Console/App.config
+++ b/PokemonGo/RocketAPI/Console/App.config
@@ -16,8 +16,9 @@
     <add key="PtcUsername" value="username" /> <!--Username-->
     <add key="PtcPassword" value="pw" /> <!--Password-->
     <add key="GoogleRefreshToken" value="" />
-    <add key="DefaultLatitude" value="48.45" /> <!--Default Viaduct Harbour, Auckland, New Zealand-->
-    <add key="DefaultLongitude" value="13.4333" /> <!--Default Viaduct Harbour, Auckland, New Zealand-->
+    <add key="LocationReference" value="Viaduct Harbour, Auckland, New Zealand" /> <!-- Location Label/Name for Reference -->
+    <add key="DefaultLatitude" value="48.45" />
+    <add key="DefaultLongitude" value="13.4333" />
     <add key="LevelOutput" value="levelup" /> <!--2 Modes: "time": Every XXX seconds and "levelup" every levelup-->
     <add key="LevelTimeInterval" value="1" /> <!--Pick 1 if levelup and time in seconds if "time"-->
     <add key="Recycler" value="true" /> <!--Recycler master switch-->

--- a/PokemonGo/RocketAPI/Console/Program.cs
+++ b/PokemonGo/RocketAPI/Console/Program.cs
@@ -164,6 +164,7 @@ namespace PokemonGo.RocketAPI.Console
                     ColoredConsoleWrite(ConsoleColor.Cyan, "Account: " + ClientSettings.PtcUsername);
                     ColoredConsoleWrite(ConsoleColor.Cyan, "Password: " + ClientSettings.PtcPassword);
                 }
+                ColoredConsoleWrite(ConsoleColor.Magenta, "Location: " + ClientSettings.LocationReference);
                 ColoredConsoleWrite(ConsoleColor.DarkGray, "Latitude: " + ClientSettings.DefaultLatitude);
                 ColoredConsoleWrite(ConsoleColor.DarkGray, "Longitude: " + ClientSettings.DefaultLongitude);
                 ColoredConsoleWrite(ConsoleColor.DarkGray, "Your Account:");

--- a/PokemonGo/RocketAPI/ISettings.cs
+++ b/PokemonGo/RocketAPI/ISettings.cs
@@ -10,6 +10,7 @@ namespace PokemonGo.RocketAPI
     public interface ISettings
     {
         AuthType AuthType { get; }
+        string LocationReference { get; }
         double DefaultLatitude { get; set; }
         double DefaultLongitude { get; set; }
         string LevelOutput { get; }

--- a/bhelper/Settings.cs
+++ b/bhelper/Settings.cs
@@ -75,6 +75,8 @@ namespace bhelper
         public bool EggHatchedOutput => GetSetting() != string.Empty ? System.Convert.ToBoolean(GetSetting(), CultureInfo.InvariantCulture) : false;
 
         public string UseLuckyEggMode => GetSetting() != string.Empty ? GetSetting() : "always";
+        
+        public string LocationReference => GetSetting() != string.Empty ? GetSetting() : "unlabeled";
 
         public string GoogleRefreshToken
         {


### PR DESCRIPTION
Added LocationReference to allow user's to specify a human-readable name within configuration for the Lat/Lon they're using.  While it is useful to just have the lat/long within the configuration; during output it can be painful to remember which lat/long belong to what without modifying the configuration.

I have numerous "Spots" within a city I check out and needed a way to quickly discern which location I was at.  This assisted with that effort.  Also with the reference we no longer need the comments within the file on lat/lon; just LocationReference.

I believe having this pull from Google Maps API, the human readable version geo-cache name of a lat, lon in the future is the answer; but this works for now.